### PR TITLE
In 8.1.2:  Fix Formula for lambda^dot

### DIFF
--- a/summaries/cs/elective/ce/opt/content.tex
+++ b/summaries/cs/elective/ce/opt/content.tex
@@ -2365,7 +2365,7 @@
 		\subsection{First-Order Necessary Optimality Conditions (Maximum Principle)}
 			Functions \( \vec{x}^\ast \), \( \vec{u}^\ast \) and \( \vec{\lambda}^\ast \not\equiv \vec{0} \) are the optimal solution of the basis problem iff the \emph{canonical differential equations}
 			\begin{align*}
-				\dot{\vec{x}} = \pdv{H}{\vec{\lambda}} \qquad \dot{\vec{\lambda}} = -\frac{H}{\vec{x}}
+				\dot{\vec{x}} = \pdv{H}{\vec{\lambda}} \qquad \dot{\vec{\lambda}} = -\pdv{H}{\vec{x}}
 			\end{align*}
 			and the boundary conditions are fulfilled and the optimal control \(\vec{u}^\ast\) minimizes the Hamilton function:
 			\begin{align}


### PR DESCRIPTION
In 8.1.2 (First-Order Necessary Optimality Conditions):  Fix Formula for lambda^dot.

Sould be:
   lambda^dot = - dH/dx

I'm am not sure if `\pdv` is the correct command for this.

Great summary btw :)