### PR TITLE
SAT(FO) & FINSAT(FO)

### DIFF
--- a/summaries/cs/mandatory/fs2/apl/content.tex
+++ b/summaries/cs/mandatory/fs2/apl/content.tex
@@ -446,10 +446,10 @@
         \item $ \text{SAT}(\text{AL}) \coloneqq \{ \varphi \in \text{AL} : \varphi \text{ erfüllbar} \} $ \\ entscheidbar
         \item $ \overline{\text{SAT}(\text{AL})} \coloneqq \{ \varphi \in \text{AL} : \varphi \text{ unerfüllbar} \} $ \\ entscheidbar
         \item $ \text{VAL}(\text{AL}) \coloneqq \{ \varphi \in \text{AL} : \varphi \text{ allgemeingültig} \} $ \\ enscheidbar
-        \item $ \text{SAT}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ erfüllbar} \} $ \\ unentscheidbar, rekursiv aufzählbar
+        \item $ \text{SAT}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ erfüllbar} \} $ \\ unentscheidbar, nicht rekursiv aufzählbar
         \item $ \overline{\text{SAT}(\text{FO})} \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ unerfüllbar} \} $ \\ unentscheidbar, rekursiv aufzählbar
         \item $ \text{VAL}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ allgemeingültig} \} $ \\ unentscheidbar, rekursiv aufwählbar
-        \item $ \text{FINSAT}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ hat ein endliches Model} \} $ \\ unentscheidbar, nicht rekursiv aufwählbar
+        \item $ \text{FINSAT}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ hat ein endliches Model} \} $ \\ unentscheidbar, rekursiv aufwählbar
         \item $ \text{INFSAT}(\text{FO}) \coloneqq \{ \varphi \in \text{FO} : \varphi \text{ hat nur unendliche Modelle} \} $ \\ unentscheidbar, nicht rekursiv aufzählbar
     \end{itemize}
 % end


### PR DESCRIPTION
"Da ist leider etwas falsch SAT(FO) ist nicht rekursiv aufzählbar. Angenommen SAT(FO) und das passende Komplement NICHT SAT(FO) wären beide rekursiv aufzählbar, dann würde der Satz von chruch und turing nicht gelten. Der sagt ja genau SAT(FO) ist nicht entscheidbar."

"neben dem [...] ist außerdem auch Finsat(FO) rekursiv aufzählbar, dafür könntest du für jede endliche Signatur S einfach für eine wachsende Trägermenge für alle Symbole aus S alle möglichen Interpretationen ausprobieren (das ist zwar ein sehr ineffizienter Semi-Entscheidungsalgorithmus, aber würde immer irgendwann "ja" ausgeben)"

https://discord.com/channels/365078454003302400/382222055019511809/1486702543273984133